### PR TITLE
fix definition of arithmetic operators

### DIFF
--- a/SQF.tmLanguage
+++ b/SQF.tmLanguage
@@ -33,7 +33,7 @@
 			<key>name</key><string>keyword.operator.comparison.sqf</string>
 		</dict>
 		<dict>
-			<key>match</key><string>\+|\-|%|&lt;&lt;|&gt;&gt;|&amp;|\||\^|~</string>
+			<key>match</key><string>\+|\-|\*|\/|%|\^</string>
 			<key>name</key><string>keyword.operator.arithmetic.sqf</string>
 		</dict>
 		<dict>


### PR DESCRIPTION
`<<`, `>>`, `&`, `|` and `~` are no math commands in SQF.
`*` and `/` are though

Please note that while `>>` exists, it is only used to navigate configs and is not a bitshift operator or anything like that.